### PR TITLE
Service worker site errors

### DIFF
--- a/myCoolServiceWorker.js
+++ b/myCoolServiceWorker.js
@@ -48,11 +48,10 @@ self.addEventListener('fetch', async e => {
 
   if (req.method !== 'GET') return;
 
-  // For SPA-ish navigation requests, serve the cached shell if available.
-  if (req.mode === 'navigate') {
-    e.respondWith(returnCachedIfAvailable('./index.html'));
-    return;
-  }
+  // Safari/WebKit: avoid intercepting top-level navigations.
+  // Some hosts use redirects for `/` <-> `/index.html`, and returning a redirected Response
+  // from a Service Worker can make Safari fail the navigation.
+  if (req.mode === 'navigate') return;
 
   if (url.origin === location.origin) {
     // Is a local resource
@@ -71,7 +70,7 @@ async function returnCachedIfAvailable(req) {
   // If there isn't anything cached, do the HTTP request
   if (cached && !isRedirectResponse(cached)) return cached;
 
-  const fresh = await fetch(req);
+  const fresh = await fetchAvoidingRedirectResponse(req);
   // Never cache redirects; only cache successful same-origin responses.
   if (isCacheableSameOriginResponse(fresh)) {
     await cache.put(req, fresh.clone());
@@ -83,7 +82,7 @@ async function fetchAndCache(req) {
   const cache = await caches.open(CACHE_NAME);
   try {
     // Try to get a fresh version of the resource first
-    const fresh = await fetch(req);
+    const fresh = await fetchAvoidingRedirectResponse(req);
     // Update the cache with fresh version (opaque is common for <img> fetches)
     if (fresh && !isRedirectResponse(fresh) && (fresh.ok || fresh.type === 'opaque')) {
       await cache.put(req, fresh.clone());
@@ -113,12 +112,32 @@ function isCacheableSameOriginResponse(res) {
   return Boolean(res && !isRedirectResponse(res) && res.status === 200 && (res.type === 'basic' || res.type === 'cors'));
 }
 
+async function fetchAvoidingRedirectResponse(req) {
+  const res = await fetch(req);
+  if (!isRedirectResponse(res)) return res;
+
+  // Safari/WebKit can fail navigations if a Service Worker returns a "redirected" Response.
+  // If the fetch followed a redirect, re-fetch the final URL directly so `redirected === false`.
+  if (res.url) {
+    try {
+      const directReq = new Request(res.url, { cache: 'no-store' });
+      const directRes = await fetch(directReq);
+      return directRes;
+    } catch (_) {
+      // If the direct fetch fails, fall back to the original response.
+      return res;
+    }
+  }
+
+  return res;
+}
+
 async function precacheStaticAssets(cache, assets) {
   for (const asset of assets) {
     try {
       // cache: 'reload' avoids an already-cached redirect being reused during install.
       const req = new Request(asset, { cache: 'reload' });
-      const res = await fetch(req);
+      const res = await fetchAvoidingRedirectResponse(req);
       if (isCacheableSameOriginResponse(res)) {
         await cache.put(req, res.clone());
       }

--- a/sw.js
+++ b/sw.js
@@ -34,6 +34,10 @@ self.addEventListener('fetch', async e => {
   const req = e.request;
   const url = new URL(req.url);
 
+  if (req.method !== 'GET') return;
+  // Avoid intercepting navigations (Safari redirect + SW is fragile).
+  if (req.mode === 'navigate') return;
+
   if (url.origin === location.origin) {
     e.respondWith(returnCachedIfAvailable(req));
   } else {
@@ -46,7 +50,7 @@ async function returnCachedIfAvailable(req) {
   const cached = await cache.match(req);
   if (cached && !isRedirectResponse(cached)) return cached;
 
-  const fresh = await fetch(req);
+  const fresh = await fetchAvoidingRedirectResponse(req);
   if (isCacheableSameOriginResponse(fresh)) {
     await cache.put(req, fresh.clone());
   }
@@ -56,7 +60,7 @@ async function returnCachedIfAvailable(req) {
 async function fetchAndCache(req) {
   const cache = await caches.open(cacheName);
   try {
-    const fresh = await fetch(req);
+    const fresh = await fetchAvoidingRedirectResponse(req);
     if (fresh && !isRedirectResponse(fresh) && (fresh.ok || fresh.type === 'opaque')) {
       await cache.put(req, fresh.clone());
     }
@@ -75,11 +79,28 @@ function isCacheableSameOriginResponse(res) {
   return Boolean(res && !isRedirectResponse(res) && res.status === 200 && (res.type === 'basic' || res.type === 'cors'));
 }
 
+async function fetchAvoidingRedirectResponse(req) {
+  const res = await fetch(req);
+  if (!isRedirectResponse(res)) return res;
+
+  if (res.url) {
+    try {
+      const directReq = new Request(res.url, { cache: 'no-store' });
+      const directRes = await fetch(directReq);
+      return directRes;
+    } catch (_) {
+      return res;
+    }
+  }
+
+  return res;
+}
+
 async function precacheStaticAssets(cache, assets) {
   for (const asset of assets) {
     try {
       const req = new Request(asset, { cache: 'reload' });
-      const res = await fetch(req);
+      const res = await fetchAvoidingRedirectResponse(req);
       if (isCacheableSameOriginResponse(res)) {
         await cache.put(req, res.clone());
       }


### PR DESCRIPTION
Stop service workers from intercepting top-level navigations and returning redirected responses to fix Safari navigation errors.

Safari's WebKit engine rejects navigations if a service worker returns a `Response` with `response.redirected` set to `true`, leading to "Response served by service worker has redirections" errors and preventing the site from loading after a few reloads. This PR prevents service workers from intercepting top-level navigations and ensures that any `Response` that was redirected is re-fetched directly to clear the `redirected` flag before being returned or cached.

---
<a href="https://cursor.com/background-agent?bcId=bc-04594818-ec08-44fb-b96e-3b71f9fdd4f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-04594818-ec08-44fb-b96e-3b71f9fdd4f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

